### PR TITLE
Add provider for freemobile

### DIFF
--- a/cmd/sachet/config.go
+++ b/cmd/sachet/config.go
@@ -37,7 +37,7 @@ var config struct {
 		Turbosms    turbosms.TurbosmsConfig
 		OTC         otc.OTCConfig
 		MediaBurst  mediaburst.MediaBurstConfig
-		FreeMobile  freemobile.FreeMobileConfig
+		FreeMobile  freemobile.Config
 	}
 
 	Receivers []ReceiverConf

--- a/cmd/sachet/config.go
+++ b/cmd/sachet/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/messagebird/sachet/provider/cm"
 	"github.com/messagebird/sachet/provider/exotel"
+	"github.com/messagebird/sachet/provider/freemobile"
 	"github.com/messagebird/sachet/provider/infobip"
 	"github.com/messagebird/sachet/provider/mediaburst"
 	"github.com/messagebird/sachet/provider/messagebird"
@@ -36,6 +37,7 @@ var config struct {
 		Turbosms    turbosms.TurbosmsConfig
 		OTC         otc.OTCConfig
 		MediaBurst  mediaburst.MediaBurstConfig
+		FreeMobile  freemobile.FreeMobileConfig
 	}
 
 	Receivers []ReceiverConf

--- a/cmd/sachet/main.go
+++ b/cmd/sachet/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/messagebird/sachet"
 	"github.com/messagebird/sachet/provider/cm"
 	"github.com/messagebird/sachet/provider/exotel"
+	"github.com/messagebird/sachet/provider/freemobile"
 	"github.com/messagebird/sachet/provider/infobip"
 	"github.com/messagebird/sachet/provider/mediaburst"
 	"github.com/messagebird/sachet/provider/messagebird"
@@ -107,12 +108,12 @@ func main() {
 		defer r.Body.Close()
 		if r.Method == "POST" {
 			log.Println("Loading configuration file", *configFile)
-			if err := LoadConfig(*configFile); err!=nil {
-               http.Error(w, err.Error(), http.StatusInternalServerError)
-			} 
-        } else {
-            http.Error(w, "Invalid request method.", http.StatusMethodNotAllowed)
-        }
+			if err := LoadConfig(*configFile); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		} else {
+			http.Error(w, "Invalid request method.", http.StatusMethodNotAllowed)
+		}
 	})
 
 	if os.Getenv("PORT") != "" {
@@ -155,6 +156,8 @@ func providerByName(name string) (sachet.Provider, error) {
 		return otc.NewOTC(config.Providers.OTC), nil
 	case "mediaburst":
 		return mediaburst.NewMediaBurst(config.Providers.MediaBurst), nil
+	case "freemobile":
+		return freemobile.NewFreeMobile(config.Providers.FreeMobile), nil
 	}
 
 	return nil, fmt.Errorf("%s: Unknown provider", name)

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -30,6 +30,10 @@ providers:
     project_id: project_id
   mediaburst:
     api_key: 'aa66sdfasfsda7887fdsf7sdf87fsdf7sdf7dsfd'
+  freemobile:
+    username: 'my-user-name'
+    password: 'secret'
+    url: "https://smsapi.free-mobile.fr/sendmsg"
 
 receivers:
   - name: 'team-sms'

--- a/provider/freemobile/freemobile.go
+++ b/provider/freemobile/freemobile.go
@@ -26,6 +26,9 @@ var freemobileHTTPClient = &http.Client{Timeout: time.Second * 20}
 
 // NewFreeMobile creates and returns a new FreeMobile struct
 func NewFreeMobile(config FreeMobileConfig) *FreeMobile {
+	if config.Url == "" {
+		config.Url = "https://smsapi.free-mobile.fr/sendmsg"
+	}
 	return &FreeMobile{config}
 }
 
@@ -59,13 +62,10 @@ func (c *FreeMobile) Send(message sachet.Message) error {
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
 
-	var body []byte
-	response.Body.Read(body)
 	if response.StatusCode == http.StatusOK && err == nil {
 		return nil
 	}
 
-	return fmt.Errorf("Failed sending sms. Reason: %s, statusCode: %d", string(body), response.StatusCode)
+	return fmt.Errorf("Failed sending sms. statusCode: %d", response.StatusCode)
 }

--- a/provider/freemobile/freemobile.go
+++ b/provider/freemobile/freemobile.go
@@ -10,29 +10,29 @@ import (
 	"github.com/messagebird/sachet"
 )
 
-// FreeMobileConfig is the configuration struct for FreeMobile provider
-type FreeMobileConfig struct {
+// Config is the configuration struct for FreeMobile provider
+type Config struct {
 	Username string `yaml:"username"`
 	Password string `yaml:"password"`
-	Url      string `yaml:"url"`
+	URL      string `yaml:"url"`
 }
 
 // FreeMobile contains the necessary values for the FreeMobile provider
 type FreeMobile struct {
-	FreeMobileConfig
+	Config
 }
 
 var freemobileHTTPClient = &http.Client{Timeout: time.Second * 20}
 
 // NewFreeMobile creates and returns a new FreeMobile struct
-func NewFreeMobile(config FreeMobileConfig) *FreeMobile {
-	if config.Url == "" {
-		config.Url = "https://smsapi.free-mobile.fr/sendmsg"
+func NewFreeMobile(config Config) *FreeMobile {
+	if config.URL == "" {
+		config.URL = "https://smsapi.free-mobile.fr/sendmsg"
 	}
 	return &FreeMobile{config}
 }
 
-type FreeMobilePayload struct {
+type payload struct {
 	User    string `json:"user"`
 	Pass    string `json:"pass"`
 	Message string `json:"msg"`
@@ -40,18 +40,18 @@ type FreeMobilePayload struct {
 
 // Send sends SMS to user registered in configuration
 func (c *FreeMobile) Send(message sachet.Message) error {
-	payload := FreeMobilePayload{
+	params := payload{
 		User:    c.Username,
 		Pass:    c.Password,
 		Message: message.Text,
 	}
 
-	data, err := json.Marshal(payload)
+	data, err := json.Marshal(params)
 	if err != nil {
 		return err
 	}
 
-	request, err := http.NewRequest("POST", c.Url, bytes.NewBuffer(data))
+	request, err := http.NewRequest("POST", c.URL, bytes.NewBuffer(data))
 	if err != nil {
 		return err
 	}

--- a/provider/freemobile/freemobile.go
+++ b/provider/freemobile/freemobile.go
@@ -1,0 +1,71 @@
+package freemobile
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/messagebird/sachet"
+)
+
+// FreeMobileConfig is the configuration struct for FreeMobile provider
+type FreeMobileConfig struct {
+	Username string `yaml:"username"`
+	Password string `yaml:"password"`
+	Url      string `yaml:"url"`
+}
+
+// FreeMobile contains the necessary values for the FreeMobile provider
+type FreeMobile struct {
+	FreeMobileConfig
+}
+
+var freemobileHTTPClient = &http.Client{Timeout: time.Second * 20}
+
+// NewFreeMobile creates and returns a new FreeMobile struct
+func NewFreeMobile(config FreeMobileConfig) *FreeMobile {
+	return &FreeMobile{config}
+}
+
+type FreeMobilePayload struct {
+	User    string `json:"user"`
+	Pass    string `json:"pass"`
+	Message string `json:"msg"`
+}
+
+// Send sends SMS to user registered in configuration
+func (c *FreeMobile) Send(message sachet.Message) error {
+	payload := FreeMobilePayload{
+		User:    c.Username,
+		Pass:    c.Password,
+		Message: message.Text,
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	request, err := http.NewRequest("POST", c.Url, bytes.NewBuffer(data))
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("User-Agent", "Sachet")
+
+	response, err := freemobileHTTPClient.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	var body []byte
+	response.Body.Read(body)
+	if response.StatusCode == http.StatusOK && err == nil {
+		return nil
+	}
+
+	return fmt.Errorf("Failed sending sms. Reason: %s, statusCode: %d", string(body), response.StatusCode)
+}


### PR DESCRIPTION
This PR adds the `FreeMobile` provider.

[FreeMobile](http://mobile.free.fr/) is French cellular provider that gives their customers access to a HTTP API to send SMS. 

`Message.To` and `Message.From` are unused for this provider since it only allows to send SMS to the mobile attached to the contract