### PR TITLE
Add message template support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,38 @@ receivers:
   - url: 'http://localhost:9876/alert'
 ```
 
+## Message templating
+
+Sachet supports Alertmanager-like templates for message content. You can do that by simply copying Alertmanager templates to Sachet. Some templates examples can be found in [the Alertmanager documentation](https://prometheus.io/docs/alerting/notification_examples/) as well as [available variables](https://prometheus.io/docs/alerting/notifications/).
+
+sachet.yml:
+```yaml
+templates:
+- /etc/sachet/notifications.tmpl
+
+receivers:
+- name: 'team-telegram'
+  provider: telegram
+  text: '{{ template "telegram_message" . }}'
+```
+notifications.tmpl:
+```
+{{ define "telegram_title" }}[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }} @ {{ .CommonLabels.identifier }} {{ end }}
+
+{{ define "telegram_message" }}
+{{ if gt (len .Alerts.Firing) 0 }}
+*Alerts Firing:*
+{{ range .Alerts.Firing }}• {{ .Labels.instance }}: {{ .Annotations.description }}
+{{ end }}{{ end }}
+{{ if gt (len .Alerts.Resolved) 0 }}
+*Alerts Resolved:*
+{{ range .Alerts.Resolved }}• {{ .Labels.instance }}: {{ .Annotations.description }}
+{{ end }}{{ end }}{{ end }}
+
+{{ define "telegram_text" }}{{ template "telegram_title" .}}
+{{ template "telegram_message" . }}{{ end }}
+```
+
 ## License
 
 Sachet is licensed under [The BSD 2-Clause License](http://opensource.org/licenses/BSD-2-Clause). Copyright (c) 2016, MessageBird

--- a/cmd/sachet/config.go
+++ b/cmd/sachet/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/messagebird/sachet/provider/turbosms"
 	"github.com/messagebird/sachet/provider/twilio"
 
+	"github.com/prometheus/alertmanager/template"
 	"gopkg.in/yaml.v2"
 )
 
@@ -24,6 +25,7 @@ type ReceiverConf struct {
 	Provider string
 	To       []string
 	From     string
+	Text     string
 }
 
 var config struct {
@@ -43,7 +45,9 @@ var config struct {
 	}
 
 	Receivers []ReceiverConf
+	Templates []string
 }
+var tmpl *template.Template
 
 // LoadConfig loads the specified YAML configuration file.
 func LoadConfig(filename string) error {
@@ -53,6 +57,11 @@ func LoadConfig(filename string) error {
 	}
 
 	err = yaml.Unmarshal(content, &config)
+	if err != nil {
+		return err
+	}
+
+	tmpl, err = template.FromGlobs(config.Templates...)
 	if err != nil {
 		return err
 	}

--- a/cmd/sachet/config.go
+++ b/cmd/sachet/config.go
@@ -62,9 +62,5 @@ func LoadConfig(filename string) error {
 	}
 
 	tmpl, err = template.FromGlobs(config.Templates...)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/cmd/sachet/main.go
+++ b/cmd/sachet/main.go
@@ -63,32 +63,40 @@ func main() {
 		}
 
 		var text string
-		if len(data.Alerts) > 1 {
-			labelAlerts := map[string]template.Alerts{
-				"Firing":   data.Alerts.Firing(),
-				"Resolved": data.Alerts.Resolved(),
+		if receiverConf.Text != "" {
+			text, err = tmpl.ExecuteTextString(receiverConf.Text, data)
+			if err != nil {
+				errorHandler(w, http.StatusInternalServerError, err, receiverConf.Provider)
+				return
 			}
-			for label, alerts := range labelAlerts {
-				if len(alerts) > 0 {
-					text += label + ": \n"
-					for _, alert := range alerts {
-						text += alert.Labels["alertname"] + " @" + alert.Labels["instance"]
-						if len(alert.Labels["exported_instance"]) > 0 {
-							text += " (" + alert.Labels["exported_instance"] + ")"
+		} else {
+			if len(data.Alerts) > 1 {
+				labelAlerts := map[string]template.Alerts{
+					"Firing":   data.Alerts.Firing(),
+					"Resolved": data.Alerts.Resolved(),
+				}
+				for label, alerts := range labelAlerts {
+					if len(alerts) > 0 {
+						text += label + ": \n"
+						for _, alert := range alerts {
+							text += alert.Labels["alertname"] + " @" + alert.Labels["instance"]
+							if len(alert.Labels["exported_instance"]) > 0 {
+								text += " (" + alert.Labels["exported_instance"] + ")"
+							}
+							text += "\n"
 						}
-						text += "\n"
 					}
 				}
+			} else if len(data.Alerts) == 1 {
+				alert := data.Alerts[0]
+				tuples := []string{}
+				for k, v := range alert.Labels {
+					tuples = append(tuples, k+"= "+v)
+				}
+				text = strings.ToUpper(data.Status) + " \n" + strings.Join(tuples, "\n")
+			} else {
+				text = "Alert \n" + strings.Join(data.CommonLabels.Values(), " | ")
 			}
-		} else if len(data.Alerts) == 1 {
-			alert := data.Alerts[0]
-			tuples := []string{}
-			for k, v := range alert.Labels {
-				tuples = append(tuples, k+"= "+v)
-			}
-			text = strings.ToUpper(data.Status) + " \n" + strings.Join(tuples, "\n")
-		} else {
-			text = "Alert \n" + strings.Join(data.CommonLabels.Values(), " | ")
 		}
 
 		message := sachet.Message{

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -38,6 +38,9 @@ providers:
     username: 'username'
     password: 'password'
 
+templates:
+  - telegram.tmpl
+
 receivers:
   - name: 'team-sms'
     provider: 'messagebird'
@@ -48,4 +51,5 @@ receivers:
     provider: 'telegram'
     to:
       - '164451814' # the chat id of a user. Get yours at https://telegram.me/userinfobot
+    text: '{{ .GroupLabels.alertname }} @ {{ .Labels.instance }}: {{ .Status | toUpper }}'
 

--- a/examples/telegram.tmpl
+++ b/examples/telegram.tmpl
@@ -1,0 +1,14 @@
+{{ define "telegram_title" }}[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }} @ {{ .CommonLabels.identifier }} {{ end }}
+
+{{ define "telegram_message" }}
+{{ if gt (len .Alerts.Firing) 0 }}
+*Alerts Firing:*
+{{ range .Alerts.Firing }}• {{ .Labels.instance }}: {{ .Annotations.description }}
+{{ end }}{{ end }}
+{{ if gt (len .Alerts.Resolved) 0 }}
+*Alerts Resolved:*
+{{ range .Alerts.Resolved }}• {{ .Labels.instance }}: {{ .Annotations.description }}
+{{ end }}{{ end }}{{ end }}
+
+{{ define "telegram_text" }}{{ template "telegram_title" .}}
+{{ template "telegram_message" . }}{{ end }}


### PR DESCRIPTION
This PR implements #3. For backward compatibility old formatting style is used when no template is defined.

It uses code from alertmanager, so configuration is similar to alertmanager's one:
```yaml
providers:

templates:
- /template.yml

receivers:
- name: test
  provider: telegram
  text: '{{ template "telegram_message" . }}'
```