### PR TITLE
add ParseMode config for Telegram

### DIFF
--- a/provider/telegram/telegram.go
+++ b/provider/telegram/telegram.go
@@ -2,27 +2,41 @@ package telegram
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/messagebird/sachet"
 	"gopkg.in/telegram-bot-api.v4"
 )
 
 type TelegramConfig struct {
-	Token string `yaml:"token"`
+	Token     string `yaml:"token"`
+	ParseMode string `yaml:"parse_mode"`
 }
 
 type Telegram struct {
-	bot *tgbotapi.BotAPI
+	bot       *tgbotapi.BotAPI
+	ParseMode string
 }
 
 func NewTelegram(config TelegramConfig) (*Telegram, error) {
+	ParseMode := strings.ToLower(config.ParseMode)
+	switch ParseMode {
+	case "md", "markdown":
+		ParseMode = "Markdown"
+	case "html", "h":
+		ParseMode = "HTML"
+	default:
+		ParseMode = ""
+	}
+
 	bot, err := tgbotapi.NewBotAPI(config.Token)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Telegram{
-		bot: bot,
+		bot:       bot,
+		ParseMode: ParseMode,
 	}, nil
 }
 
@@ -33,6 +47,7 @@ func (tg *Telegram) Send(message sachet.Message) error {
 			return err
 		}
 		msg := tgbotapi.NewMessage(chatID, message.Text)
+		msg.ParseMode = tg.ParseMode
 		_, err = tg.bot.Send(msg)
 		if err != nil {
 			return err


### PR DESCRIPTION
add support Markdown and HTML ParseMode
https://core.telegram.org/bots/api#formatting-options