### PR TITLE
Add Pushbullet provider

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,131 +3,184 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = "UT"
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  digest = "1:004d308dffe0ab15d83f7dc98ec8c42c843666df1a50537a4ff38ed4cf187f2c"
   name = "github.com/carlosdp/twiliogo"
   packages = ["."]
+  pruneopts = "UT"
   revision = "f61c8230fa91b87ca5c16a21a661861208749dfe"
   version = "v0.1"
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "UT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:15042ad3498153684d09f393bbaec6b216c8eec6d61f63dff711de7d64ed8861"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
+  pruneopts = "UT"
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:5985ef4caf91ece5d54817c11ea25f182697534f8ae6521eadcd628c142ac4b6"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
+  pruneopts = "UT"
   revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:98dc904e7724bf8f5b26809d39fb706d37b45fa30a838240b334dfbadc7befbb"
   name = "github.com/messagebird/go-rest-api"
   packages = ["."]
+  pruneopts = "UT"
   revision = "a9514230491e7db6adaa58162cce34a5df987fd4"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:4b0a77e3bb3c0ddf54cff8dca385a744edc3625be3b9b55492ed6a14de4c13e6"
   name = "github.com/prometheus/alertmanager"
   packages = [
     "template",
     "template/internal/deftmpl",
-    "types"
+    "types",
   ]
+  pruneopts = "UT"
   revision = "30af4d051b37ce817ea7e35b56c57a0e2ec9dbb0"
   version = "v0.14.0"
 
 [[projects]]
+  digest = "1:b6221ec0f8903b556e127c449e7106b63e6867170c2d10a7c058623d086f2081"
   name = "github.com/prometheus/client_golang"
   packages = ["prometheus"]
+  pruneopts = "UT"
   revision = "c5b7fccd204277076155f10851dad72b76a49317"
   version = "v0.8.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:32d10bdfa8f09ecf13598324dba86ab891f11db3c538b6a34d1c3b5b99d7c36b"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
+  pruneopts = "UT"
   revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
 
 [[projects]]
   branch = "master"
+  digest = "1:e469cd65badf7694aeb44874518606d93c1d59e7735d3754ad442782437d3cc3"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "model"
+    "model",
   ]
+  pruneopts = "UT"
   revision = "d811d2e9bf898806ecfb6ef6296774b13ffc314c"
 
 [[projects]]
   branch = "master"
+  digest = "1:570784e0ddbf67f14087c6d8cfb7b999b9c55e75518a755e88cb202566ea8a17"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/util",
     "nfs",
-    "xfs"
+    "xfs",
   ]
+  pruneopts = "UT"
   revision = "8b1c2da0d56deffdbb9e48d4414b4e674bd8083e"
 
 [[projects]]
+  digest = "1:1bc4a5bd879ce6b44fdaa2e8e1144921c145604764e92220009b951c1f2439f5"
   name = "github.com/stretchr/objx"
   packages = ["."]
+  pruneopts = "UT"
   revision = "facf9a85c22f48d2f52f2380e4efce1768749a89"
   version = "v0.1"
 
 [[projects]]
+  digest = "1:eca8319bce847b7208ed5ae89ef2efb28586a7095657217241641e1da78a3c13"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "mock"
+    "mock",
   ]
+  pruneopts = "UT"
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
 
 [[projects]]
+  digest = "1:420817f94b6c172dabb8a054d0b2d257d7437a87c7c8c7ee432bc008a577fc46"
   name = "github.com/technoweenie/multipartstreamer"
   packages = ["."]
+  pruneopts = "UT"
   revision = "a90a01d73ae432e2611d178c18367fbaa13e0154"
   version = "v1.0.1"
 
 [[projects]]
+  branch = "master"
+  digest = "1:ff865c5772fd1d5dfc30dfd225f9faf545661c35aa774c972411a2ec4af7cd2a"
+  name = "github.com/xconstruct/go-pushbullet"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "67759df45fbbd23cbe3d5cdc6df7891c5b663cb8"
+
+[[projects]]
+  digest = "1:81ccd59248f60553288016a6b5cb7d988fb9c11e21b713a951790647332528bd"
   name = "gopkg.in/njern/gonexmo.v1"
   packages = ["."]
+  pruneopts = "UT"
   revision = "c83191e580d14eb435e39f0317a89c6912b094a4"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:6999e4e34bb73184674e844d6d1e6f48f75a30a9c86ef7663dbc7b2509962812"
   name = "gopkg.in/telegram-bot-api.v4"
   packages = ["."]
+  pruneopts = "UT"
   revision = "0e0af0c480ea98e982d5f4d45fb39577c6ab1e3e"
   version = "v4.6.2"
 
 [[projects]]
+  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5f8fe62dbc923ac817a9bbbb22dad207fce7420d6a8d36a73c5f4e6c83232d47"
+  input-imports = [
+    "github.com/carlosdp/twiliogo",
+    "github.com/messagebird/go-rest-api",
+    "github.com/prometheus/alertmanager/template",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/xconstruct/go-pushbullet",
+    "gopkg.in/njern/gonexmo.v1",
+    "gopkg.in/telegram-bot-api.v4",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/sachet/config.go
+++ b/cmd/sachet/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/messagebird/sachet/provider/messagebird"
 	"github.com/messagebird/sachet/provider/nexmo"
 	"github.com/messagebird/sachet/provider/otc"
+	"github.com/messagebird/sachet/provider/pushbullet"
 	"github.com/messagebird/sachet/provider/sipgate"
 	"github.com/messagebird/sachet/provider/telegram"
 	"github.com/messagebird/sachet/provider/turbosms"
@@ -44,6 +45,7 @@ var config struct {
 		FreeMobile  freemobile.Config
 		AspSms      aspsms.Config
 		Sipgate     sipgate.Config
+		Pushbullet  pushbullet.Config
 	}
 
 	Receivers []ReceiverConf

--- a/cmd/sachet/main.go
+++ b/cmd/sachet/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/messagebird/sachet/provider/messagebird"
 	"github.com/messagebird/sachet/provider/nexmo"
 	"github.com/messagebird/sachet/provider/otc"
+	"github.com/messagebird/sachet/provider/pushbullet"
 	"github.com/messagebird/sachet/provider/sipgate"
 	"github.com/messagebird/sachet/provider/telegram"
 	"github.com/messagebird/sachet/provider/turbosms"
@@ -174,6 +175,8 @@ func providerByName(name string) (sachet.Provider, error) {
 		return aspsms.NewAspSms(config.Providers.AspSms), nil
 	case "sipgate":
 		return sipgate.NewSipgate(config.Providers.Sipgate), nil
+	case "pushbullet":
+		return pushbullet.NewPushbullet(config.Providers.Pushbullet), nil
 	}
 
 	return nil, fmt.Errorf("%s: Unknown provider", name)

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -40,6 +40,8 @@ providers:
   sipgate:
     username: 'username'
     password: 'password'
+  pushbullet:
+    access_token: 'o.AbCdEfGhIjKlMnOpQrStUvWxYz012345'
 
 templates:
   - telegram.tmpl
@@ -55,4 +57,8 @@ receivers:
     to:
       - '164451814' # the chat id of a user. Get yours at https://telegram.me/userinfobot
     text: '{{ .GroupLabels.alertname }} @ {{ .Labels.instance }}: {{ .Status | toUpper }}'
-
+  - name: 'pushbullet'
+    provider: 'pushbullet'
+    to:
+      - device:My Nickname
+      - channel:mytag

--- a/provider/pushbullet/README.md
+++ b/provider/pushbullet/README.md
@@ -1,0 +1,20 @@
+# Pushbullet
+
+To configure the Pushbullet provider, you need to specify an access token, which can be generated in your [account settings](https://www.pushbullet.com/#settings/account).
+
+```
+providers:
+    pushbullet:
+        access_token: 'o.AbCdEfGhIjKlMnOpQrStUvWxYz012345'
+```
+
+To configure a pushbullet receiver you must specify a list of targets in the form `targetType:targetName` where the format of the name depends on the type. Currently pushing to a device or to subscribers of a channel are supported.
+
+```
+receivers:
+- name: 'pushbullet'
+    provider: 'pushbullet'
+    to:
+      - device:My Nickname
+      - channel:mytag
+```

--- a/provider/pushbullet/pushbullet.go
+++ b/provider/pushbullet/pushbullet.go
@@ -1,0 +1,88 @@
+package pushbullet
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/messagebird/sachet"
+	"github.com/xconstruct/go-pushbullet"
+)
+
+const (
+	deviceTargetType  = "device"
+	channelTargetType = "channel"
+)
+
+// Config is the configuration struct for the Pushbullet provider
+type Config struct {
+	AccessToken string `yaml:"access_token"`
+}
+
+// Pushbullet contains the necessary values for the Pushbullet provider
+type Pushbullet struct {
+	Config
+}
+
+// NewPushbullet creates and returns a new Pushbullet struct
+func NewPushbullet(config Config) *Pushbullet {
+	return &Pushbullet{config}
+}
+
+// Send pushes a note to devices registered in configuration
+func (c *Pushbullet) Send(message sachet.Message) error {
+
+	for _, recipient := range message.To {
+
+		// create pushbullet client
+		pb := pushbullet.New(c.AccessToken)
+
+		// parse recipient
+		targetTypeName := strings.Split(recipient, ":")
+		if len(targetTypeName) != 2 {
+			return fmt.Errorf("cannot parse recipient %s: expecting targetType:targetName", recipient)
+		}
+		targetType := targetTypeName[0]
+		targetName := targetTypeName[1]
+
+		switch targetType {
+		case deviceTargetType:
+			// retrieve device
+			dev, err := pb.Device(targetName)
+			if err != nil {
+				return err
+			}
+
+			// push note
+			err = pb.PushNote(dev.Iden, message.From, message.Text)
+			if err != nil {
+				return err
+			}
+		case channelTargetType:
+			// retrieve subscription
+			sub, err := pb.Subscription(targetName)
+			if err != nil {
+				return err
+			}
+
+			// push note
+			err = sub.PushNote(message.From, message.Text)
+			if err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unrecognised target type: %s", targetType)
+		}
+
+	}
+
+	return nil
+}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}

--- a/provider/pushbullet/pushbullet.go
+++ b/provider/pushbullet/pushbullet.go
@@ -37,7 +37,7 @@ func (c *Pushbullet) Send(message sachet.Message) error {
 		pb := pushbullet.New(c.AccessToken)
 
 		// parse recipient
-		targetTypeName := strings.Split(recipient, ":")
+		targetTypeName := strings.SplitN(recipient, ":", 2)
 		if len(targetTypeName) != 2 {
 			return fmt.Errorf("cannot parse recipient %s: expecting targetType:targetName", recipient)
 		}

--- a/vendor/github.com/xconstruct/go-pushbullet/.travis.yml
+++ b/vendor/github.com/xconstruct/go-pushbullet/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+go:
+  - tip
+before_install:
+  - go get github.com/mattn/goveralls
+script:
+  - goveralls --service=travis-ci --repotoken erZSOzTiDwnegx7UEkCTqGXCtK9940t52 -package .

--- a/vendor/github.com/xconstruct/go-pushbullet/LICENSE
+++ b/vendor/github.com/xconstruct/go-pushbullet/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Constantin Schomburg <me@cschomburg.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/xconstruct/go-pushbullet/README.md
+++ b/vendor/github.com/xconstruct/go-pushbullet/README.md
@@ -1,0 +1,79 @@
+go-pushbullet
+=============
+
+[![Build](https://img.shields.io/travis/xconstruct/go-pushbullet.svg?style=flat-square)](https://travis-ci.org/xconstruct/go-pushbullet)
+[![Coverage](https://img.shields.io/coveralls/xconstruct/go-pushbullet.svg?style=flat-square)](https://coveralls.io/github/xconstruct/go-pushbullet)
+[![API Documentation](https://img.shields.io/badge/api-GoDoc-blue.svg?style=flat-square)](https://godoc.org/github.com/xconstruct/go-pushbullet)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](http://opensource.org/licenses/MIT)
+
+Simple Go client for [Pushbullet](http://pushbullet.com), a webservice to push
+links, notes and more to your Android devices.
+
+Documentation available under: http://godoc.org/github.com/xconstruct/go-pushbullet
+
+### Install ###
+
+	go get "github.com/xconstruct/go-pushbullet"
+
+### Example ###
+
+```go
+pb := pushbullet.New("YOUR_API_KEY")
+devs, err := pb.Devices()
+if err != nil {
+	panic(err)
+}
+
+err = pb.PushNote(devs[0].Iden, "Hello!", "Hi from go-pushbullet!")
+if err != nil {
+	panic(err)
+}
+
+
+user, err := pb.Me()
+if err != nil {
+	panic(err)
+}
+
+err = pb.PushSMS(user.Iden, devs[0].Iden, "<TARGET_PHONE_NUMBER>", "Sms text")
+if err != nil {
+	panic(err)
+}
+```
+
+You can also retrieve a pushbullet device by nickname, and call the same methods as you would with the pushbullet client  
+```go
+dev, err := pb.Device("My Phone")
+if err != nil {
+	panic(err)
+}
+
+err = dev.PushNote("Hello!", "Straight to device with just a title and body")
+if err != nil {
+	panic(err)
+}
+```
+
+Channels are also supported in a similar manner  
+```go
+subs, err := pb.Subscriptions()
+if err != nil {
+	panic(err)
+}
+
+err = pb.PushNoteToChannel(subs[0].Channel.Tag, "Hello!", "Hi from go-pushbullet!")
+if err != nil {
+	panic(err)
+}
+
+sub, err := pb.Subscription("MyChannelTag")
+if err != nil {
+	panic(err)
+}
+
+err = sub.PushNote("Hello!", "Straight to Channel with just a title and body")
+if err != nil {
+	panic(err)
+}
+
+```

--- a/vendor/github.com/xconstruct/go-pushbullet/pushbullet.go
+++ b/vendor/github.com/xconstruct/go-pushbullet/pushbullet.go
@@ -1,0 +1,423 @@
+// Package pushbullet provides simple access to the v2 API of http://pushbullet.com.
+/*
+
+Example client:
+	pb := pushbullet.New("YOUR_API_KEY")
+	devices, err := pb.Devices()
+	...
+	err = pb.PushNote(devices[0].Iden, "Hello!", "Hi from go-pushbullet!")
+
+The API is document at https://docs.pushbullet.com/http/ .  At the moment, it only supports querying devices and sending notifications.
+
+*/
+package pushbullet
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+// ErrDeviceNotFound is raised when device nickname is not found on pusbullet server
+var ErrDeviceNotFound = errors.New("Device not found")
+
+// EndpointURL sets the default URL for the Pushbullet API
+var EndpointURL = "https://api.pushbullet.com/v2"
+
+// Endpoint allows manipulation of pushbullet API endpoint for testing
+type Endpoint struct {
+	URL string
+}
+
+// A Client connects to PushBullet with an API Key.
+type Client struct {
+	Key    string
+	Client *http.Client
+	Endpoint
+}
+
+// New creates a new client with your personal API key.
+func New(apikey string) *Client {
+	endpoint := Endpoint{URL: EndpointURL}
+	return &Client{apikey, http.DefaultClient, endpoint}
+}
+
+// NewWithClient creates a new client with your personal API key and the given http Client
+func NewWithClient(apikey string, client *http.Client) *Client {
+	endpoint := Endpoint{URL: EndpointURL}
+	return &Client{apikey, client, endpoint}
+}
+
+// A Device is a PushBullet device
+type Device struct {
+	Iden              string  `json:"iden"`
+	Active            bool    `json:"active"`
+	Created           float32 `json:"created"`
+	Modified          float32 `json:"modified"`
+	Icon              string  `json:"icon"`
+	Nickname          string  `json:"nickname"`
+	GeneratedNickname bool    `json:"generated_nickname"`
+	Manufacturer      string  `json:"manufacturer"`
+	Model             string  `json:"model"`
+	AppVersion        int     `json:"app_version"`
+	Fingerprint       string  `json:"fingerprint"`
+	KeyFingerprint    string  `json:"key_fingerprint"`
+	PushToken         string  `json:"push_token"`
+	HasSms            bool    `json:"has_sms"`
+	Client            *Client `json:"-"`
+}
+
+// ErrResponse is an error returned by the PushBullet API
+type ErrResponse struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+	Cat     string `json:"cat"`
+}
+
+func (e *ErrResponse) Error() string {
+	return e.Message
+}
+
+type errorResponse struct {
+	ErrResponse `json:"error"`
+}
+
+type deviceResponse struct {
+	Devices       []*Device
+	SharedDevices []*Device `json:"shared_devices"`
+}
+
+type subscriptionResponse struct {
+	Subscriptions []*Subscription
+}
+
+func (c *Client) buildRequest(object string, data interface{}) *http.Request {
+	r, err := http.NewRequest("GET", c.Endpoint.URL+object, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	// appengine sdk requires us to set the auth header by hand
+	u := url.UserPassword(c.Key, "")
+	r.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(u.String())))
+
+	if data != nil {
+		r.Method = "POST"
+		r.Header.Set("Content-Type", "application/json")
+		var b bytes.Buffer
+		enc := json.NewEncoder(&b)
+		enc.Encode(data)
+		r.Body = ioutil.NopCloser(&b)
+	}
+
+	return r
+}
+
+// Devices fetches a list of devices from PushBullet.
+func (c *Client) Devices() ([]*Device, error) {
+	req := c.buildRequest("/devices", nil)
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		var errjson errorResponse
+		dec := json.NewDecoder(resp.Body)
+		err = dec.Decode(&errjson)
+		if err == nil {
+			return nil, &errjson.ErrResponse
+		}
+
+		return nil, errors.New(resp.Status)
+	}
+
+	var devResp deviceResponse
+	dec := json.NewDecoder(resp.Body)
+	err = dec.Decode(&devResp)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range devResp.Devices {
+		devResp.Devices[i].Client = c
+	}
+	devices := append(devResp.Devices, devResp.SharedDevices...)
+	return devices, nil
+}
+
+// Device fetches an device with a given nickname from PushBullet.
+func (c *Client) Device(nickname string) (*Device, error) {
+	devices, err := c.Devices()
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range devices {
+		if devices[i].Nickname == nickname {
+			devices[i].Client = c
+			return devices[i], nil
+		}
+	}
+	return nil, ErrDeviceNotFound
+}
+
+// PushNote sends a note to the specific device with the given title and body
+func (d *Device) PushNote(title, body string) error {
+	return d.Client.PushNote(d.Iden, title, body)
+}
+
+// PushLink sends a link to the specific device with the given title and url
+func (d *Device) PushLink(title, u, body string) error {
+	return d.Client.PushLink(d.Iden, title, u, body)
+}
+
+// PushSMS sends an SMS to the specific user from the device with the given title and url
+func (d *Device) PushSMS(deviceIden, phoneNumber, message string) error {
+	return d.Client.PushSMS(d.Iden, deviceIden, phoneNumber, message)
+}
+
+// User represents the User object for pushbullet
+type User struct {
+	Iden            string      `json:"iden"`
+	Email           string      `json:"email"`
+	EmailNormalized string      `json:"email_normalized"`
+	Created         float64     `json:"created"`
+	Modified        float64     `json:"modified"`
+	Name            string      `json:"name"`
+	ImageUrl        string      `json:"image_url"`
+	Preferences     interface{} `json:"preferences"`
+}
+
+// Me returns the user object for the pushbullet user
+func (c *Client) Me() (*User, error) {
+	req := c.buildRequest("/users/me", nil)
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		var errjson errorResponse
+		dec := json.NewDecoder(resp.Body)
+		err = dec.Decode(&errjson)
+		if err == nil {
+			return nil, &errjson.ErrResponse
+		}
+
+		return nil, errors.New(resp.Status)
+	}
+
+	var userResponse User
+	dec := json.NewDecoder(resp.Body)
+	err = dec.Decode(&userResponse)
+	if err != nil {
+		return nil, err
+	}
+	return &userResponse, nil
+}
+
+// Push pushes the data to a specific device registered with PushBullet.  The
+// 'data' parameter is marshaled to JSON and sent as the request body.  Most
+// users should call one of PusNote, PushLink, PushAddress, or PushList.
+func (c *Client) Push(endPoint string, data interface{}) error {
+	req := c.buildRequest(endPoint, data)
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var errResponse errorResponse
+		dec := json.NewDecoder(resp.Body)
+		err = dec.Decode(&errResponse)
+		if err == nil {
+			return &errResponse.ErrResponse
+		}
+
+		return errors.New(resp.Status)
+	}
+
+	return nil
+}
+
+// Note exposes the required and optional fields of the Pushbullet push type=note
+type Note struct {
+	Iden  string `json:"device_iden,omitempty"`
+	Tag   string `json:"channel_tag,omitempty"`
+	Type  string `json:"type"`
+	Title string `json:"title"`
+	Body  string `json:"body"`
+}
+
+// PushNote pushes a note with title and body to a specific PushBullet device.
+func (c *Client) PushNote(iden string, title, body string) error {
+	data := Note{
+		Iden:  iden,
+		Type:  "note",
+		Title: title,
+		Body:  body,
+	}
+	return c.Push("/pushes", data)
+}
+
+// PushNoteToChannel pushes a note with title and body to a specific PushBullet channel.
+func (c *Client) PushNoteToChannel(tag string, title, body string) error {
+	data := Note{
+		Tag:   tag,
+		Type:  "note",
+		Title: title,
+		Body:  body,
+	}
+	return c.Push("/pushes", data)
+}
+
+// Link exposes the required and optional fields of the Pushbullet push type=link
+type Link struct {
+	Iden  string `json:"device_iden,omitempty"`
+	Tag   string `json:"channel_tag,omitempty"`
+	Type  string `json:"type"`
+	Title string `json:"title"`
+	URL   string `json:"url"`
+	Body  string `json:"body,omitempty"`
+}
+
+// PushLink pushes a link with a title and url to a specific PushBullet device.
+func (c *Client) PushLink(iden, title, u, body string) error {
+	data := Link{
+		Iden:  iden,
+		Type:  "link",
+		Title: title,
+		URL:   u,
+		Body:  body,
+	}
+	return c.Push("/pushes", data)
+}
+
+// PushLinkToChannel pushes a link with a title and url to a specific PushBullet device.
+func (c *Client) PushLinkToChannel(tag, title, u, body string) error {
+	data := Link{
+		Tag:   tag,
+		Type:  "link",
+		Title: title,
+		URL:   u,
+		Body:  body,
+	}
+	return c.Push("/pushes", data)
+}
+
+// EphemeralPush  exposes the required fields of the Pushbullet ephemeral object
+type EphemeralPush struct {
+	Type             string `json:"type"`
+	PackageName      string `json:"package_name"`
+	SourceUserIden   string `json:"source_user_iden"`
+	TargetDeviceIden string `json:"target_device_iden"`
+	ConversationIden string `json:"conversation_iden"`
+	Message          string `json:"message"`
+}
+
+// Ephemeral constructs the Ephemeral object for pushing which requires the EphemeralPush object
+type Ephemeral struct {
+	Type string        `json:"type"`
+	Push EphemeralPush `json:"push"`
+}
+
+// PushSMS sends an SMS message with pushbullet
+func (c *Client) PushSMS(userIden, deviceIden, phoneNumber, message string) error {
+	data := Ephemeral{
+		Type: "push",
+		Push: EphemeralPush{
+			Type:             "messaging_extension_reply",
+			PackageName:      "com.pushbullet.android",
+			SourceUserIden:   userIden,
+			TargetDeviceIden: deviceIden,
+			ConversationIden: phoneNumber,
+			Message:          message,
+		},
+	}
+	return c.Push("/ephemerals", data)
+}
+
+// Subscription object allows interaction with pushbullet channels
+type Subscription struct {
+	Iden     string   `json:"iden"`
+	Active   bool     `json:"active"`
+	Created  float32  `json:"created"`
+	Modified float32  `json:"modified"`
+	Muted    string   `json:"muted"`
+	Channel  *Channel `json:"channel"`
+	Client   *Client  `json:"-"`
+}
+
+// Channel object contains specific information about the pushbullet Channel
+type Channel struct {
+	Iden        string `json:"iden"`
+	Tag         string `json:"tag"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	ImageUrl    string `json:"image_url"`
+	WebsiteUrl  string `json:"website_url"`
+}
+
+func (c *Client) Subscriptions() ([]*Subscription, error) {
+	req := c.buildRequest("/subscriptions", nil)
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		var errjson errorResponse
+		dec := json.NewDecoder(resp.Body)
+		err = dec.Decode(&errjson)
+		if err == nil {
+			return nil, &errjson.ErrResponse
+		}
+
+		return nil, errors.New(resp.Status)
+	}
+
+	var subResp subscriptionResponse
+	dec := json.NewDecoder(resp.Body)
+	err = dec.Decode(&subResp)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range subResp.Subscriptions {
+		subResp.Subscriptions[i].Client = c
+	}
+	subscriptions := append(subResp.Subscriptions)
+	return subscriptions, nil
+}
+
+// Subscription fetches an subscription with a given channel tag from PushBullet.
+func (c *Client) Subscription(tag string) (*Subscription, error) {
+	subs, err := c.Subscriptions()
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range subs {
+		if subs[i].Channel.Tag == tag {
+			subs[i].Client = c
+			return subs[i], nil
+		}
+	}
+	return nil, ErrDeviceNotFound
+}
+
+// PushNote sends a note to the specific Channel with the given title and body
+func (s *Subscription) PushNote(title, body string) error {
+	return s.Client.PushNoteToChannel(s.Channel.Tag, title, body)
+}
+
+// PushNote sends a link to the specific Channel with the given title, url and body
+func (s *Subscription) PushLink(title, u, body string) error {
+	return s.Client.PushLinkToChannel(s.Channel.Tag, title, u, body)
+}


### PR DESCRIPTION
Adds support sending notes to either a device or a channel using [Pushbullet](https://www.pushbullet.com/).

Other target types are supported but not yet implemented: https://docs.pushbullet.com/#target-parameters