### PR TITLE
Remove unused contains function

### DIFF
--- a/provider/pushbullet/pushbullet.go
+++ b/provider/pushbullet/pushbullet.go
@@ -77,12 +77,3 @@ func (c *Pushbullet) Send(message sachet.Message) error {
 
 	return nil
 }
-
-func contains(s []string, e string) bool {
-	for _, a := range s {
-		if a == e {
-			return true
-		}
-	}
-	return false
-}


### PR DESCRIPTION
I left in a `contains` function from a previous implementation of the Pushbullet provider which is no longer needed: https://github.com/messagebird/sachet/pull/61/files

This PR removes that function.