### PR TITLE
Fix kannel username attribute in example config

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -18,7 +18,7 @@ providers:
   kannel:
     # url: "http://localhost:13013/cgi-bin/sendsms"
     url: "http://httpbin.org/get"
-    user: "tester"
+    username: "tester"
     password: "foobar"
   exotel:
     account_sid: 'sachet'


### PR DESCRIPTION
There was a typo in the example config related to kannel username. This PR fixes that.