### PR TITLE
wrong config name

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -82,7 +82,7 @@ providers:
   sap:
     url: "https://sms-pp.sapmobileservices.com/cmn/xxxxx/xxxxx.sms"
     auth_hash: ""
-  kavehnegar:
+  kavenegar:
     api_token: 'KAVENEGAR_API_TOKEN'
 
 templates:


### PR DESCRIPTION
there is an extra h in the config name
`kaveHnegar` changed to `kavenegar`