### PR TITLE
Add Esendex provider

### DIFF
--- a/cmd/sachet/config.go
+++ b/cmd/sachet/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/messagebird/sachet/provider/esendex"
 	"io/ioutil"
 
 	"github.com/messagebird/sachet/provider/aliyun"
@@ -65,6 +66,7 @@ var config struct {
 		OVH          ovh.Config
 		TencentCloud tencentcloud.Config
 		Sap          sap.Config
+		Esendex      esendex.Config
 	}
 
 	Receivers []ReceiverConf

--- a/cmd/sachet/main.go
+++ b/cmd/sachet/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"github.com/messagebird/sachet/provider/esendex"
 	"log"
 	"net/http"
 	"os"
@@ -216,6 +217,8 @@ func providerByName(name string) (sachet.Provider, error) {
 		return tencentcloud.NewTencentCloud(config.Providers.TencentCloud)
 	case "sap":
 		return sap.NewSap(config.Providers.Sap), nil
+	case "esendex":
+		return esendex.NewEsendex(config.Providers.Esendex), nil
 	}
 
 	return nil, fmt.Errorf("%s: Unknown provider", name)

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -84,6 +84,10 @@ providers:
     auth_hash: ""
   kavenegar:
     api_token: 'KAVENEGAR_API_TOKEN'
+  esendex:
+    user: 'name'
+    api_token: 'TOKEN'
+    account_reference: 'reference'
 
 templates:
   - telegram.tmpl

--- a/provider/esendex/esendex.go
+++ b/provider/esendex/esendex.go
@@ -1,0 +1,114 @@
+package esendex
+
+// Provider for https://developers.esendex.com/api-reference
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/messagebird/sachet"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+const (
+	timeout  = time.Second * 60
+	endpoint = "https://api.esendex.com/v1.0/messagedispatcher"
+)
+
+type Config struct {
+	User             string `yaml:"user"`
+	ApiToken         string `yaml:"api_token"`
+	AccountReference string `yaml:"account_reference"`
+}
+
+type Esendex struct {
+	Config
+	httpClient *http.Client
+}
+
+func NewEsendex(config Config) *Esendex {
+	return &Esendex{
+		config,
+		&http.Client{Timeout: timeout},
+	}
+}
+
+func (e *Esendex) Send(message sachet.Message) (err error) {
+	for _, phoneNumber := range message.To {
+		err = e.sendOne(message, phoneNumber)
+
+		if err != nil {
+			return fmt.Errorf("failed to make API call to Esendex: %s", err)
+		}
+	}
+
+	return
+}
+
+// JSON example for one message. The payload may contain multiple messages. The to property may
+// contain more than one phone number separated by comma.
+//	{
+//	"accountreference":"xxx",
+//	"messages":[{
+//		"from": "from",
+//		"to":"phonenuber1,phonenuber2,phonenuber3",
+//		"body":"Hogla, Bogla!"
+//	}]
+//	}
+type requestPayload struct {
+	AccountReference string           `json:"accountreference"`
+	Messages         []requestMessage `json:"messages"`
+}
+
+type requestMessage struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+	Body string `json:"body"`
+}
+
+func (e *Esendex) sendOne(message sachet.Message, phoneNumber string) (err error) {
+	params := requestPayload{
+		AccountReference: e.AccountReference,
+		Messages: []requestMessage{
+			{
+				From: message.From,
+				To:   phoneNumber,
+				Body: message.Text,
+			},
+		},
+	}
+
+	data, err := json.Marshal(params)
+
+	if err != nil {
+		return err
+	}
+
+	var request *http.Request
+	request, err = http.NewRequest("POST", endpoint, bytes.NewBuffer(data))
+
+	if err != nil {
+		return
+	}
+
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("User-Agent", "Sachet")
+	request.SetBasicAuth(e.Config.User, e.Config.ApiToken)
+
+	response, err := e.httpClient.Do(request)
+
+	if err != nil {
+		return err
+	}
+
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(response.Body)
+		return fmt.Errorf("SMS sending failed. HTTP status code: %d, Response body: %s", response.StatusCode, body)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Hi there,

we use Sachet with Prometheus Alertmanager to send SMS via [Esendex](https://www.esendex.com/) at our company www.iteratec.de. I would like to donate this provider to the project.