### PR TITLE
add no_stop and priority options to OVH provider

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -71,6 +71,7 @@ providers:
     consumer_key: consumer_key
     service_name: sms-xxx-1
     sender_for_response: true # True if the SMS can be reply by the receiver (if false from in receiver must valid and recorded in OVH API)
+    no_stop_clause: true # True if you don't need STOP clause at the end on the message
   tencentcloud:
     region_id: ap-shanghai
     secret_id: AKIDWqaCa1aNL3V0MtSG7mCZPjvrgJhqdgeN

--- a/provider/ovh/ovh.go
+++ b/provider/ovh/ovh.go
@@ -8,14 +8,15 @@ import (
 )
 
 type Config struct {
-	Endpoint             string `yaml:"endpoint"`
-	ApplicationKey       string `yaml:"application_key"`
-	ApplicationSecret    string `yaml:"application_secret"`
-	ConsumerKey          string `yaml:"consumer_key"`
+	Endpoint          string `yaml:"endpoint"`
+	ApplicationKey    string `yaml:"application_key"`
+	ApplicationSecret string `yaml:"application_secret"`
+	ConsumerKey       string `yaml:"consumer_key"`
 
-	ServiceName          string `yaml:"service_name"`
-	SenderForResponse    string `yaml:"sender_for_response"`
-	NoStopClause         bool   `yaml:"no_stop_clause"`
+	ServiceName       string `yaml:"service_name"`
+	SenderForResponse string `yaml:"sender_for_response"`
+	NoStopClause      bool   `yaml:"no_stop_clause"`
+	Priority          string `yaml:"priority"`
 }
 
 type Ovh struct {
@@ -48,12 +49,14 @@ func (ovh *Ovh) Send(message sachet.Message) error {
 		sms["message"] = message.Text
 		sms["noStopClause"] = &ovh.config.NoStopClause
 		sms["sender"] = message.From
-		senderForResponse := &ovh.config.SenderForResponse
-		sms["senderForResponse"] = senderForResponse
+		sms["senderForResponse"] = &ovh.config.SenderForResponse
 		sms["receivers"] = message.To
+		if ovh.config.Priority != "" {
+			sms["priority"] = &ovh.config.Priority
+		}
 		serviceName := &ovh.config.ServiceName
 
-		if err := ovh.client.Post("/sms/" + *serviceName + "/jobs", sms, nil); err != nil {
+		if err := ovh.client.Post("/sms/"+*serviceName+"/jobs", sms, nil); err != nil {
 			return err
 		}
 

--- a/provider/ovh/ovh.go
+++ b/provider/ovh/ovh.go
@@ -15,6 +15,7 @@ type Config struct {
 
 	ServiceName          string `yaml:"service_name"`
 	SenderForResponse    string `yaml:"sender_for_response"`
+	NoStopClause         bool   `default:"false" yaml:"no_stop_clause"`
 }
 
 type Ovh struct {
@@ -45,7 +46,7 @@ func (ovh *Ovh) Send(message sachet.Message) error {
 		type ovhSMS map[string]interface{}
 		sms := make(ovhSMS)
 		sms["message"] = message.Text
-		sms["noStopClause"] = false
+		sms["noStopClause"] = &ovh.config.NoStopClause
 		sms["sender"] = message.From
 		senderForResponse := &ovh.config.SenderForResponse
 		sms["senderForResponse"] = senderForResponse

--- a/provider/ovh/ovh.go
+++ b/provider/ovh/ovh.go
@@ -3,8 +3,8 @@ package ovh
 import (
 	"fmt"
 
-	"github.com/ovh/go-ovh/ovh"
 	"github.com/messagebird/sachet"
+	"github.com/ovh/go-ovh/ovh"
 )
 
 type Config struct {
@@ -15,7 +15,7 @@ type Config struct {
 
 	ServiceName          string `yaml:"service_name"`
 	SenderForResponse    string `yaml:"sender_for_response"`
-	NoStopClause         bool   `default:"false" yaml:"no_stop_clause"`
+	NoStopClause         bool   `yaml:"no_stop_clause"`
 }
 
 type Ovh struct {


### PR DESCRIPTION
Hello

Just adding `no_stop_clause` config to OVH provider and leave default value to `false` (`bool` is `false` by default) to respect old configuration.